### PR TITLE
Compatibility for 64 bits platforms

### DIFF
--- a/Common/Vcl.Styles.Hooks.pas
+++ b/Common/Vcl.Styles.Hooks.pas
@@ -461,10 +461,10 @@ begin
         LHandle:=Trampoline_user32_LoadIconW(_hInstance, lpIconName);
         LIcon.Handle := LHandle;
         Result := LHandle;
-        s := IntToStr(Integer(lpIconName));
+        s := IntToStr(NativeUInt(lpIconName));
 
         //OutputDebugString(PChar('Detour_LoadIconW '+s+ ' Module Name '+GetModuleName(_hInstance)+' _hInstance '+IntToHex(_hInstance, 8) ));
-        case Integer(lpIconName) of
+        case NativeUInt(lpIconName) of
          78: DrawIcon(fa_shield);
          81: DrawIcon(fa_info_circle);
          84: DrawIcon(fa_warning);
@@ -473,7 +473,7 @@ begin
         end;
 
         if _hInstance=0 then
-        case Integer(lpIconName) of
+        case NativeUInt(lpIconName) of
          32518 : DrawIcon(fa_shield);
          32516 : DrawIcon(fa_info_circle);
          32515 : DrawIcon(fa_warning);
@@ -509,9 +509,9 @@ begin
                                                                                                                          //w8 - W10
   if (hInst>0) and (hInst<>HInstance) and (ImageType=IMAGE_ICON) and (X=16) and (Y=16) and IS_INTRESOURCE(ImageName) and TOSVersion.Check(6, 2) then
   begin
-    s := IntToStr(Integer(ImageName));
+    s := IntToStr(NativeUInt(ImageName));
 
-     case Integer(ImageName) of
+     case NativeUInt(ImageName) of
         //W8, W10
         //comctl32.dll
         16817
@@ -543,7 +543,7 @@ begin
     hModule:=GetModuleHandle(ExplorerFrame);
     if (hModule = hInst) then
     begin
-      s := IntToStr(Integer(ImageName));
+      s := IntToStr(NativeUInt(ImageName));
       Result:= Trampoline_user32_LoadImageW(hInst, ImageName, ImageType, X, Y, Flags);
       LBitmap:=TBitmap.Create;
       try
@@ -555,7 +555,7 @@ begin
         begin
           LBackColor:= StyleServices.GetSystemColor(clWindow);
           LRect:=Rect(0, 0, LBitmap.Width, LBitmap.Height );
-           case Integer(ImageName) of
+           case NativeUInt(ImageName) of
              // Right Arrow, cross button, refresh, down arrow
               288
                       :
@@ -595,7 +595,7 @@ begin
         begin
           LBackColor:= StyleServices.GetSystemColor(clWindow);
           LRect:=Rect(0, 0, LBitmap.Width, LBitmap.Height );
-          case Integer(ImageName) of
+          case NativeUInt(ImageName) of
            //Magnifier
            34560..34562,  // Aero Enabled
            34563..34568   // Classic Theme
@@ -685,7 +685,7 @@ begin
                     :
                      begin
 
-                        case Integer(ImageName) of
+                        case NativeUInt(ImageName) of
                           577 : LColor:= StyleServices.GetSystemColor(clBtnText);
                           578 : LColor:= StyleServices.GetSystemColor(clHighlight);
                           579 : LColor:= StyleServices.GetSystemColor(clGrayText);
@@ -713,7 +713,7 @@ begin
                     :
                      begin
 
-                        case Integer(ImageName) of
+                        case NativeUInt(ImageName) of
                           582 : LColor:= StyleServices.GetSystemColor(clBtnText);
                           583 : LColor:= StyleServices.GetSystemColor(clHighlight);
                           584 : LColor:= StyleServices.GetSystemColor(clGrayText);

--- a/Common/Vcl.Styles.Utils.Graphics.pas
+++ b/Common/Vcl.Styles.Utils.Graphics.pas
@@ -1432,10 +1432,10 @@ var
   r, g, b, a   : byte;
   x, y:    integer;
   ARGB:    TColor;
-  Line, Delta: integer;
+  Line, Delta: NativeInt;
 begin
-  Line  := integer(Dest.ScanLine[0]);
-  Delta := integer(Dest.ScanLine[1]) - Line;
+  Line  := NativeInt(Dest.ScanLine[0]);
+  Delta := NativeInt(Dest.ScanLine[1]) - Line;
   for y := 0 to Dest.Height - 1 do
   begin
     for x := 0 to Dest.Width - 1 do
@@ -1480,8 +1480,8 @@ var
   r, g, b, a   : byte;
   x, y:    integer;
   ARGB:    TColor;
-  LineDest, DeltaDest: integer;
-  LineSource, DeltaSource: integer;
+  LineDest, DeltaDest: NativeInt;
+  LineSource, DeltaSource: NativeInt;
   Value : TColor;
   SourceN : TBitmap;
 begin
@@ -1502,11 +1502,11 @@ begin
       y := y + Source.Height;
     end;
 
-    LineDest  := integer(Dest.ScanLine[0]);
-    DeltaDest := integer(Dest.ScanLine[1]) - LineDest;
+    LineDest  := NativeInt(Dest.ScanLine[0]);
+    DeltaDest := NativeInt(Dest.ScanLine[1]) - LineDest;
 
-    LineSource  := integer(SourceN.ScanLine[0]);
-    DeltaSource := integer(SourceN.ScanLine[1]) - LineSource;
+    LineSource  := NativeInt(SourceN.ScanLine[0]);
+    DeltaSource := NativeInt(SourceN.ScanLine[1]) - LineSource;
 
     for y := 0 to Dest.Height - 1 do
     begin
@@ -1562,10 +1562,10 @@ var
   r, g, b    : byte;
   x, y:    integer;
   ARGB:    TColor;
-  Line, Delta: integer;
+  Line, Delta: NativeInt;
 begin
-  Line  := integer(ABitMap.ScanLine[0]);
-  Delta := integer(ABitMap.ScanLine[1]) - Line;
+  Line  := NativeInt(ABitMap.ScanLine[0]);
+  Delta := NativeInt(ABitMap.ScanLine[1]) - Line;
   for y := 0 to ABitMap.Height - 1 do
   begin
     for x := 0 to ABitMap.Width - 1 do
@@ -1610,8 +1610,8 @@ var
   r, g, b   : byte;
   x, y:    integer;
   ARGB:    TColor;
-  LineDest, DeltaDest: integer;
-  LineSource, DeltaSource: integer;
+  LineDest, DeltaDest: NativeInt;
+  LineSource, DeltaSource: NativeInt;
   Value : TColor;
   SourceN : TBitmap;
 begin
@@ -1632,11 +1632,11 @@ begin
       y := y + Source.Height;
     end;
 
-    LineDest  := integer(Dest.ScanLine[0]);
-    DeltaDest := integer(Dest.ScanLine[1]) - LineDest;
+    LineDest  := NativeInt(Dest.ScanLine[0]);
+    DeltaDest := NativeInt(Dest.ScanLine[1]) - LineDest;
 
-    LineSource  := integer(SourceN.ScanLine[0]);
-    DeltaSource := integer(SourceN.ScanLine[1]) - LineSource;
+    LineSource  := NativeInt(SourceN.ScanLine[0]);
+    DeltaSource := NativeInt(SourceN.ScanLine[1]) - LineSource;
 
     for y := 0 to Dest.Height - 1 do
     begin
@@ -2120,10 +2120,10 @@ procedure _SetRGB24(const ABitMap: TBitmap; DR,DG,DB: Integer);
 var
   r, g, b : byte;
   x, y:    integer;
-  Line, Delta: integer;
+  Line, Delta: NativeInt;
 begin
-  Line  := integer(ABitMap.ScanLine[0]);
-  Delta := integer(ABitMap.ScanLine[1]) - Line;
+  Line  := NativeInt(ABitMap.ScanLine[0]);
+  Delta := NativeInt(ABitMap.ScanLine[1]) - Line;
   for y := 0 to ABitMap.Height - 1 do
   begin
     for x := 0 to ABitMap.Width - 1 do
@@ -2144,10 +2144,10 @@ procedure _SetRGB32(const ABitMap: TBitmap; DR,DG,DB: Integer);
 var
   r, g, b, a: byte;
   x, y:    integer;
-  Line, Delta: integer;
+  Line, Delta: NativeInt;
 begin
-  Line  := integer(ABitMap.ScanLine[0]);
-  Delta := integer(ABitMap.ScanLine[1]) - Line;
+  Line  := NativeInt(ABitMap.ScanLine[0]);
+  Delta := NativeInt(ABitMap.ScanLine[1]) - Line;
   for y := 0 to ABitMap.Height - 1 do
   begin
     for x := 0 to ABitMap.Width - 1 do

--- a/Tools/Extras/PngImageList.pas
+++ b/Tools/Extras/PngImageList.pas
@@ -167,7 +167,7 @@ begin
     Move(PByte(OldPtr)^, Patch.OldBody[0], SizeOf(Patch.OldBody));
     if VirtualProtect(OldPtr, 16, PAGE_EXECUTE_READWRITE, @Access) then begin
       PByte(OldPtr)^ := $E9; // Near jump
-      PCardinal(Cardinal(OldPtr) + 1)^ := Cardinal(NewPtr) - Cardinal(OldPtr) - 5;
+      PCardinal(NativeInt(OldPtr) + 1)^ := NativeInt(NewPtr) - NativeInt(OldPtr) - 5;
       VirtualProtect(OldPtr, 16, Access, @Access);
       Result := True;
     end;


### PR DESCRIPTION
When running on 64 bits platforms with heavy load, we found that we would occasionally get totally black menu items or even crashes the whole program.

After a bit of debugging, we found that it comes from the fact some code inside this library is casting pointers to Integer inside Vcl.Styles.Utils.Graphics.

To be on the safe side, this pull request offers to change all pointer casts to NativeUInt/NativeInt even if we did not prove (yet) they could lead to similar crashes.