### PR TITLE
Fixed a memory leak.

### DIFF
--- a/Common/Vcl.Styles.DPIAware.pas
+++ b/Common/Vcl.Styles.DPIAware.pas
@@ -140,7 +140,11 @@ begin
 end;
 
 destructor TStyleDPIAwareness.Destroy;
+var
+  i : Integer;
 begin
+  for i := 0 to FScaledStyles.Count - 1 do
+    TStyleDPI(FScaledStyles.Objects[i]).Free;
   FScaledStyles.Free;
   inherited;
 end;


### PR DESCRIPTION
Hello. RRUZ

Fixed a memory leak.

FStyledStyles in TStyleDPIAwareness class 
did not seem to properly destroy TStyleDPI 
objects recorded in Objects. This has been 
fixed.
