### PR TITLE
Added the handling of class "ExplorerStatusBar".

### DIFF
--- a/Common/VCL.Styles.Utils.inc
+++ b/Common/VCL.Styles.Utils.inc
@@ -18,14 +18,16 @@
 // All Rights Reserved.
 //
 //************************************************************************************************
+
 {$DEFINE USE_Vcl.Styles.Hooks}
 {$DEFINE HOOK_UXTHEME}
 {$DEFINE HOOK_TDateTimePicker}
 {$DEFINE HOOK_TProgressBar}
 {.$DEFINE LimitStylesToMainApplicationThread}
 {.$DEFINE HOOK_VirtualShell}
-{$DEFINE HOOK_ExplorerStatusBar}
+{.$DEFINE HOOK_ExplorerStatusBar}
 { Feature toggles for supported UxThemes - see Vcl.Styles.UxTheme }
+
 {$DEFINE HOOK_Button}
 {$DEFINE HOOK_AllButtons}
 {$DEFINE HOOK_Scrollbar}

--- a/Common/VCL.Styles.Utils.inc
+++ b/Common/VCL.Styles.Utils.inc
@@ -18,16 +18,14 @@
 // All Rights Reserved.
 //
 //************************************************************************************************
-
 {$DEFINE USE_Vcl.Styles.Hooks}
 {$DEFINE HOOK_UXTHEME}
 {$DEFINE HOOK_TDateTimePicker}
 {$DEFINE HOOK_TProgressBar}
 {.$DEFINE LimitStylesToMainApplicationThread}
 {.$DEFINE HOOK_VirtualShell}
-
+{$DEFINE HOOK_ExplorerStatusBar}
 { Feature toggles for supported UxThemes - see Vcl.Styles.UxTheme }
-
 {$DEFINE HOOK_Button}
 {$DEFINE HOOK_AllButtons}
 {$DEFINE HOOK_Scrollbar}

--- a/Common/Vcl.Styles.UxTheme.pas
+++ b/Common/Vcl.Styles.UxTheme.pas
@@ -152,6 +152,10 @@ const
   MARLETT_MAXIMIZE_CHAR = Char(49);
 {$ENDIF}
 
+{$IFDEF HOOK_ExplorerStatusBar}
+  VSCLASS_EXPLORERSTATUSBAR = 'ExplorerStatusBar';
+{$IFEND}
+
 type
   TDrawThemeBackground = function(hTheme: hTheme; hdc: hdc; iPartId, iStateId: Integer; const pRect: TRect; Foo: Pointer): HRESULT; stdcall;
   TFuncDrawThemeBackground  =  function(hTheme: HTHEME; hdc: HDC; iPartId, iStateId: Integer; const pRect: TRect; Foo: Pointer; Trampoline: TDrawThemeBackground; LThemeClass: string; hwnd: HWND): HRESULT; stdcall;
@@ -1037,6 +1041,25 @@ begin
       Result := S_OK;
       // if pColor=clNone then
       // OutputDebugString(PChar(Format('Detour_GetThemeColor Class %s hTheme %d iPartId %d iStateId %d  iPropId %d Color %8.x', [LThemeClass, hTheme, iPartId, iStateId, iPropId, pColor])));
+    end
+    else
+    {$ENDIF}
+    {$IFDEF HOOK_EXPLORERSTATUSBAR}
+    if SameText(LThemeClass, VSCLASS_EXPLORERSTATUSBAR) then
+    begin
+      pColor := clNone;
+      if (iPartId = 0) and (iStateId = 0) then
+      begin
+        pColor := ColorToRGB(StyleServices.GetSystemColor(clWindow));
+      end;
+      if TColor(pColor) = clNone then
+      begin
+        // OutputDebugString(PChar(Format('Detour_GetThemeColor Class %s hTheme %d iPartId %d iStateId %d  iPropId %d Color %8.x', [LThemeClass, hTheme, iPartId, iStateId, iPropId, pColor])));
+        Result := Trampoline_UxTheme_GetThemeColor(hTheme, iPartId, iStateId, iPropId, pColor);
+      end
+      else
+        Result := S_OK;
+
     end
     else
     {$ENDIF}


### PR DESCRIPTION
VCL-Styles-Utils manages to style the "[ExplorerBrowser](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-iexplorerbrowser)" very well, except for the StatusBar subcomponent. 
An optional fix for this has been integrated, it can be activated via "HOOK_ExplorerStatusBar".