### PR TITLE
Fix blank submenus for popup menus that are not owned by a form

### DIFF
--- a/Common/Vcl.Styles.Utils.Menus.pas
+++ b/Common/Vcl.Styles.Utils.Menus.pas
@@ -2106,6 +2106,13 @@ var
     LMenuItem: TMenuItem;
     i: integer;
   begin
+    { An item without children never owns a submenu HMENU: TMenuItem.AppendTo only passes
+      hSubMenu when GetCount > 0. Reading TMenuItem.Handle, on the other hand, CREATES one,
+      because TMenuItem.GetHandle allocates whenever FHandle = 0. Leaving early therefore
+      avoids allocating a USER menu handle for every leaf item this lookup walks over. }
+    Result := nil;
+    if AMenu.Count = 0 then
+      Exit;
     if (AMenu.Handle = FMenu) then
       Result := AMenu
     else
@@ -2124,9 +2131,23 @@ var
 begin
   Result := nil;
 
+  { PopupList holds every TPopupMenu regardless of its Owner, but comparing only the popup's own
+    handle cannot match a submenu, whose HMENU belongs to a TMenuItem rather than to the
+    TPopupMenu. Walking the item tree here makes this route work for popup menus that are not a
+    component of a form - for example one created as TPopupMenu.Create(nil) and filled at run
+    time, which the Screen.Forms scan below can never reach. Without it VCLMenuItems is nil for
+    such a submenu, so GetItemText falls back to GetMenuItemInfo(MIIM_STRING), which is empty for
+    an MFT_OWNERDRAW item - and TMenuItem.AppendTo flags every item MFT_OWNERDRAW as soon as the
+    menu has an Images list - leaving the submenu painted with neither caption nor image. }
   for i := 0 to PopupList.Count - 1 do
-    if TPopupMenu(PopupList.Items[i]).Handle = FMenu then
-      Exit(TPopupMenu(PopupList.Items[i]).Items);
+  begin
+    LPopupMenu := TPopupMenu(PopupList.Items[i]);
+    if LPopupMenu.Handle = FMenu then
+      Exit(LPopupMenu.Items);
+    Result := GetMenuItem(LPopupMenu.Items);
+    if Assigned(Result) then
+      Exit;
+  end;
 
   for i := 0 to Screen.FormCount - 1 do
   begin


### PR DESCRIPTION
GetVCLMenuItems maps a native menu item back to its VCL TMenuItem so that TSysPopupStyleHook can read the caption and the image. There is one case the two existing lookup routes do not reach: a submenu of a popup menu that is not a component of a form.

* The PopupList loop compares the TPopupMenu's own handle, and a submenu's HMENU belongs to a TMenuItem rather than to the TPopupMenu.
* The Screen.Forms scan needs the popup, or its items, to be a component of a form. A menu created as TPopupMenu.Create(nil) and filled at run time is a component of nothing.

The root menu still resolves, because TPopupMenu.Create registers itself in PopupList regardless of Owner, so only the submenus are affected - which makes the symptom easy to misread.

For those items GetItemText then falls back to GetMenuItemInfo(MIIM_STRING), which returns nothing for an MFT_OWNERDRAW item, and TMenuItem.AppendTo flags every item MFT_OWNERDRAW as soon as the menu has an Images list. The submenu ends up with neither caption nor image - an empty box of the right size, since the VCL still answers WM_MEASUREITEM.

This change lets the PopupList route look one level further down, into the item tree. That keeps it independent of Owner, in keeping with what the shortcut already does, and a hit there also skips the much larger Screen.Forms x Components x ownership walk below it.

The second hunk guards GetMenuItem against childless items, mainly because the first hunk widens how much of the item tree gets walked. Reading TMenuItem.Handle creates an HMENU when FHandle = 0, and a childless item can never be the menu being painted, since TMenuItem.AppendTo passes hSubMenu only when GetCount > 0. The existing GetMenuItem callers get the same small saving.

Verified on Delphi 13 (compiler 37.0) / Win64 with a run-time built TPopupMenu.Create(nil) that has an Images list and a submenu: before the change the submenu shows no text and no icons under a non-system VCL style, afterwards it renders normally. The system style is unaffected either way, since the hook only paints when StyleServices.IsSystemStyle is False.